### PR TITLE
Fix compilation warnings under Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.h.in
 config.log
 config.status
 configure
+compile
 depcomp
 install-sh
 missing
@@ -17,5 +18,6 @@ src/.deps/
 src/Makefile
 src/Makefile.in
 src/mfoc
+src/mfoc.exe
 stamp-h1
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,13 +2,13 @@ AC_INIT([mfoc],[0.10.7],[mifare@nethemba.com])
 
 AC_CONFIG_MACRO_DIR([m4])
 
-AC_PROG_CC
-
 AC_CONFIG_HEADERS([config.h])
 
 AC_CONFIG_SRCDIR([src/mfoc.c])
 
 AM_INIT_AUTOMAKE(dist-bzip2 no-dist-gzip)
+
+AC_PROG_CC
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
This PR adds some Cygwin files to gitignore (an auxiliar autogenerated script named "compile", and the resulting binary).

I've also fixed a beningn warning thrown by aclocal about missing m4 directory:
`aclocal-1.14: warning: couldn't open directory 'm4': No such file or directory`
I've created an empty one and added a dummy file called ".empty" so Git tracks the said folder.

Finally, I've fixed another error, caused by an improper ordering of macros in configure.ac:
```
/bin/sh: /home/Marcos/missing: No such file or directory
configure: WARNING: 'missing' script is too old or missing
```
The fix has been extracted from automake's mailing list: http://lists.gnu.org/archive/html/automake/2010-08/msg00113.html