### PR TITLE
Bugfix mfoc.c Mifare 0.3k

### DIFF
--- a/src/mfoc.c
+++ b/src/mfoc.c
@@ -680,7 +680,7 @@ int main(int argc, char *const argv[])
     }
 
     // Finally save all keys + data to file
-    uint16_t dump_size = (t.num_blocks + 1) * t.num_sectors;
+    uint16_t dump_size = (t.num_blocks + 1) * 16;
     if (fwrite(&mtDump, 1, dump_size, pfDump) != dump_size) {
       fprintf(stdout, "Error, cannot write dump\n");
       fclose(pfDump);


### PR DESCRIPTION
Bug: Mifare 0.3k tag has 5 sectors with 20 blocks = 100 bytes. Thats too small for 320 bytes.

Edited the size calculation of the target file for the dump to support Mifare 0.3K tags.
Dump file will be sized as follows: 16 bytes / block \* number of blocks.
