### PR TITLE
Alternative Mifare 1K SAK

### DIFF
--- a/src/mfoc.c
+++ b/src/mfoc.c
@@ -285,6 +285,7 @@ int main(int argc, char *const argv[])
     case 0x01:
     case 0x08:
     case 0x88:
+    case 0x19:
       if (get_rats_is_2k(t, r)) {
           printf("Found Mifare Plus 2k tag\n");
           t.num_sectors = NR_TRAILERS_2k;


### PR DESCRIPTION
I bought chinese Mifare 1K and the SAK was 19. I managed to make everything work by just adding the 19 SAK to the list so it might be useful to integrate this change in mfoc.